### PR TITLE
Replace large numeric value with java's max int value

### DIFF
--- a/client/src/sldsLanguageClient.ts
+++ b/client/src/sldsLanguageClient.ts
@@ -77,21 +77,18 @@ function createServerPromise(context: ExtensionContext, outputChannel: OutputCha
 	return new Promise((resolve, reject) => {
 		var server = net.createServer((socket) => {
 			outputChannel.appendLine("SLDS Started");
+
+			const matcher = /("character":1.7976931348623157e\+308)/;
+			const javaMaxIntValue = 2147483647;
+			const replacer = '"character":' + javaMaxIntValue + '}}';
 			
 			// Temporary solution for an LWC plugin issue where the end character range is too large for SLDS LSP server.
 			let filteredDuplex = new class extends Transform {
 				_transform(chunk: any, encoding: string, callback: TransformCallback) {
-
 					let buf = Buffer.from(chunk).toString();
-					let matcher = /("character":1.7976931348623157e\+308)/;
-				
-					if (matcher.test(buf)) {
-						let javaMaxIntValue = 2147483647;
-						let replacer = '"character":' + javaMaxIntValue + '}}';
-						buf = buf.replace(matcher, replacer);
-						chunk = Buffer.from(buf);
-					}
-										
+					buf = buf.replace(matcher, replacer);
+					chunk = Buffer.from(buf);
+								
 					this.push(chunk, encoding);
 					callback();
 				}

--- a/client/src/sldsLanguageClient.ts
+++ b/client/src/sldsLanguageClient.ts
@@ -13,6 +13,7 @@ import * as net from 'net';
 import * as child_process from "child_process";
 import { workspace, ExtensionContext, OutputChannel } from 'vscode';
 import { LanguageClient, LanguageClientOptions, StreamInfo } from 'vscode-languageclient';
+import { Transform, TransformCallback } from 'stream';
 
 declare var v8debug: any;
 const DEBUG = (typeof v8debug === 'object') || startedInDebugMode();
@@ -76,10 +77,31 @@ function createServerPromise(context: ExtensionContext, outputChannel: OutputCha
 	return new Promise((resolve, reject) => {
 		var server = net.createServer((socket) => {
 			outputChannel.appendLine("SLDS Started");
+			
+			// Temporary solution for an LWC plugin issue where the end character range is too large for SLDS LSP server.
+			let filteredDuplex = new class extends Transform {
+				_transform(chunk: any, encoding: string, callback: TransformCallback) {
+
+					let buf = Buffer.from(chunk).toString();
+					let matcher = /("character":1.7976931348623157e\+308)/;
+				
+					if (matcher.test(buf)) {
+						let javaMaxIntValue = 2147483647;
+						let replacer = '"character":' + javaMaxIntValue + '}}';
+						buf = buf.replace(matcher, replacer);
+						chunk = Buffer.from(buf);
+					}
+										
+					this.push(chunk, encoding);
+					callback();
+				}
+			} ();
+
+			filteredDuplex.pipe(socket);
 
 			resolve({
 				reader: socket,
-				writer: socket
+				writer: filteredDuplex
 			});
 		})
 		.on('end', () => console.log("Disconnected"))


### PR DESCRIPTION
### What does this PR do?

This is a temporary solution for a LWC plugin issue that causes the SLDS LSP server to return an error since the character end range is too big. This string replaces instances of a large integer to a smaller max value.

It will look something like this:
```json
"context":{"diagnostics":[{"range":{"start":{"line":12,"character":4},"end":{"line":12,"character":2147483647}}
```

### What issues does this PR fix or reference?

Resolves: https://github.com/salesforce-ux/design-system-tooling/issues/501
