### PR TITLE
Update Java Detection logic

### DIFF
--- a/client/src/sldsLanguageClient.ts
+++ b/client/src/sldsLanguageClient.ts
@@ -38,17 +38,20 @@ function findJavaExecutable(binname: string) {
 	// First search if they have an existing java.home Apex setting
 	let javaApexConfig: string | undefined = readJavaConfig();
 	if (javaApexConfig) {
-		return findBinPath(javaApexConfig, binname);
+		const binpath = findBinPath(javaApexConfig, binname);
+		if (binpath) return binpath;
 	}
 
 	// Then search each JAVA_HOME bin folder
 	if (process.env['JAVA_HOME']) {
-		return findBinPath(process.env['JAVA_HOME'], binname);
+		const binpath = findBinPath(process.env['JAVA_HOME'], binname);
+		if (binpath) return binpath;
 	}
 
 	// Then search each JDK_HOME bin folder
 	if (process.env['JDK_HOME']) {
-		return findBinPath(process.env['JDK_HOME'], binname);
+		const binpath = findBinPath(process.env['JDK_HOME'], binname);
+		if (binpath) return binpath;
 	}
 
 	// Else return the binary name directly (this will likely always fail downstream)
@@ -65,6 +68,7 @@ function findBinPath(config: string, binname: string) {
 		}
 	}
 
+	return null;
 }
 
 function readJavaConfig(): string {


### PR DESCRIPTION
1. First use apex java.home setting
2. Then JAVA_HOME
3. Lastly, JDK_HOME

### What does this PR do?

This updates the java detection logic. First, it checks if Apex's `java.home` setting is enabled. This setting will make more sense when we include this extension as a part of the Salesforce Extension pack. Then we check for JAVA_HOME, then lastly JDK_HOME.

### What issues does this PR fix or reference?

Resolves https://github.com/salesforce-ux/design-system-tooling/issues/446
