### PR TITLE
Respect Telemetry disabled via the CLI settings

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -19,5 +19,3 @@ export const TELEMETRY_OPT_OUT_LINK = 'https://developer.salesforce.com/tools/vs
 export const PUSH_OR_DEPLOY_ON_SAVE_ENABLED = 'push-or-deploy-on-save.enabled';
 export const RETRIEVE_TEST_CODE_COVERAGE = 'retrieve-test-code-coverage';
 export const SFDX_CLI_DOWNLOAD_LINK = 'https://developer.salesforce.com/tools/sfdxcli';
-export const SFDX_CONFIG_DISABLE_TELEMETRY = 'disableTelemetry';
-export const ENV_SFDX_DISABLE_TELEMETRY = 'SFDX_DISABLE_TELEMETRY';

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -19,3 +19,5 @@ export const TELEMETRY_OPT_OUT_LINK = 'https://developer.salesforce.com/tools/vs
 export const PUSH_OR_DEPLOY_ON_SAVE_ENABLED = 'push-or-deploy-on-save.enabled';
 export const RETRIEVE_TEST_CODE_COVERAGE = 'retrieve-test-code-coverage';
 export const SFDX_CLI_DOWNLOAD_LINK = 'https://developer.salesforce.com/tools/sfdxcli';
+export const SFDX_CONFIG_DISABLE_TELEMETRY = 'disableTelemetry';
+export const ENV_SFDX_DISABLE_TELEMETRY = 'SFDX_DISABLE_TELEMETRY';

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -19,9 +19,9 @@ import { telemetryService } from './telemetry';
 
 const outputChannel : vscode.OutputChannel = vscode.window.createOutputChannel(`SLDS`);
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
 	// Telemetry service
-	telemetryService.initializeService(context);
+	await telemetryService.initializeService(context);
 	telemetryService.showTelemetryMessage();
 	const extensionHRStart = process.hrtime();
 

--- a/client/src/settings/index.ts
+++ b/client/src/settings/index.ts
@@ -8,4 +8,3 @@
 import { SfdxCoreSettings } from './sfdxCoreSettings';
 
 export const sfdxCoreSettings = SfdxCoreSettings.getInstance();
-//export { registerPushOrDeployOnSave } from './pushOrDeployOnSave';

--- a/client/src/telemetry/telemetry.ts
+++ b/client/src/telemetry/telemetry.ts
@@ -40,7 +40,7 @@ export class TelemetryService {
 
 	public async initializeService(context: vscode.ExtensionContext): Promise<void> {
 		this.context = context;
-		this.cliAllowsTelemetry = await this.checkCliTelemetry();
+		this.cliAllowsTelemetry = await sfdxCoreExtension.exports.telemetryService.checkCliTelemetry();
 		const machineId = vscode && vscode.env ? vscode.env.machineId : 'someValue.machineId';
 		const isDevMode = machineId === 'someValue.machineId';
 
@@ -59,6 +59,8 @@ export class TelemetryService {
 
 			this.context.subscriptions.push(this.reporter);
 		}
+
+		this.setCliTelemetryEnabled(this.isTelemetryEnabled());
 	}
 
 	public isTelemetryEnabled(): boolean {
@@ -162,10 +164,6 @@ export class TelemetryService {
 	private getEndHRTime(hrstart: [number, number]): string {
 		const hrend = process.hrtime(hrstart);
 		return util.format('%d%d', hrend[0], hrend[1] / 1000000);
-	}
-
-	public async checkCliTelemetry(): Promise<boolean> {
-		return await sfdxCoreExtension.exports.isCLITelemetryAllowed(sfdxCoreExtension.exports.getRootWorkspacePath());
 	}
 
 	public setCliTelemetryEnabled(isEnabled: boolean) {

--- a/client/src/telemetry/telemetry.ts
+++ b/client/src/telemetry/telemetry.ts
@@ -12,8 +12,7 @@ import TelemetryReporter from './telemetryReporter';
 import {
 	TELEMETRY_GLOBAL_VALUE,
 	EXTENSION_NAME,
-	TELEMETRY_OPT_OUT_LINK,
-	SFDX_CONFIG_DISABLE_TELEMETRY
+	TELEMETRY_OPT_OUT_LINK
 } from '../constants';
 
 const sfdxCoreExtension = vscode.extensions.getExtension(

--- a/client/src/telemetry/telemetry.ts
+++ b/client/src/telemetry/telemetry.ts
@@ -15,6 +15,10 @@ import {
 	TELEMETRY_OPT_OUT_LINK
 } from '../constants';
 
+const sfdxCoreExtension = vscode.extensions.getExtension(
+	'salesforce.salesforcedx-vscode-core'
+);
+
 interface CommandMetric {
 	extensionName: string;
 	commandName: string;
@@ -25,6 +29,7 @@ export class TelemetryService {
 	private static instance: TelemetryService;
 	private context: vscode.ExtensionContext | undefined;
 	private reporter: TelemetryReporter | undefined;
+	private cliAllowsTelemetry: boolean = true;
 
 	public static getInstance() {
 		if (!TelemetryService.instance) {
@@ -33,10 +38,12 @@ export class TelemetryService {
 		return TelemetryService.instance;
 	}
 
-	public initializeService(context: vscode.ExtensionContext): void {
+	public async initializeService(context: vscode.ExtensionContext): Promise<void> {
 		this.context = context;
+		this.cliAllowsTelemetry = await this.checkCliTelemetry();
 		const machineId = vscode && vscode.env ? vscode.env.machineId : 'someValue.machineId';
 		const isDevMode = machineId === 'someValue.machineId';
+
 		// TelemetryReporter is not initialized if user has disabled telemetry setting.
 		if (this.reporter === undefined && this.isTelemetryEnabled() && !isDevMode) {
 			const extensionPackage = require(this.context.asAbsolutePath(
@@ -55,7 +62,7 @@ export class TelemetryService {
 	}
 
 	public isTelemetryEnabled(): boolean {
-		return sfdxCoreSettings.getTelemetryEnabled();
+		return sfdxCoreSettings.getTelemetryEnabled() && this.cliAllowsTelemetry;
 	}
 
 	private getHasTelemetryMessageBeenShown(): boolean {
@@ -155,6 +162,16 @@ export class TelemetryService {
 	private getEndHRTime(hrstart: [number, number]): string {
 		const hrend = process.hrtime(hrstart);
 		return util.format('%d%d', hrend[0], hrend[1] / 1000000);
+	}
+
+	public async checkCliTelemetry(): Promise<boolean> {
+		return await sfdxCoreExtension.exports.isCLITelemetryAllowed(sfdxCoreExtension.exports.getRootWorkspacePath());
+	}
+
+	public setCliTelemetryEnabled(isEnabled: boolean) {
+		if (!isEnabled) {
+			sfdxCoreExtension.exports.disableCLITelemetry();
+		}
 	}
 
 }

--- a/client/src/telemetry/telemetry.ts
+++ b/client/src/telemetry/telemetry.ts
@@ -12,12 +12,14 @@ import TelemetryReporter from './telemetryReporter';
 import {
 	TELEMETRY_GLOBAL_VALUE,
 	EXTENSION_NAME,
-	TELEMETRY_OPT_OUT_LINK
+	TELEMETRY_OPT_OUT_LINK,
+	SFDX_CONFIG_DISABLE_TELEMETRY
 } from '../constants';
 
 const sfdxCoreExtension = vscode.extensions.getExtension(
 	'salesforce.salesforcedx-vscode-core'
 );
+const sfdxCoreExports = sfdxCoreExtension.exports;
 
 interface CommandMetric {
 	extensionName: string;
@@ -40,7 +42,7 @@ export class TelemetryService {
 
 	public async initializeService(context: vscode.ExtensionContext): Promise<void> {
 		this.context = context;
-		this.cliAllowsTelemetry = await sfdxCoreExtension.exports.telemetryService.checkCliTelemetry();
+		this.cliAllowsTelemetry = await sfdxCoreExports.telemetryService.checkCliTelemetry();
 		const machineId = vscode && vscode.env ? vscode.env.machineId : 'someValue.machineId';
 		const isDevMode = machineId === 'someValue.machineId';
 
@@ -59,8 +61,6 @@ export class TelemetryService {
 
 			this.context.subscriptions.push(this.reporter);
 		}
-
-		this.setCliTelemetryEnabled(this.isTelemetryEnabled());
 	}
 
 	public isTelemetryEnabled(): boolean {
@@ -165,11 +165,4 @@ export class TelemetryService {
 		const hrend = process.hrtime(hrstart);
 		return util.format('%d%d', hrend[0], hrend[1] / 1000000);
 	}
-
-	public setCliTelemetryEnabled(isEnabled: boolean) {
-		if (!isEnabled) {
-			sfdxCoreExtension.exports.disableCLITelemetry();
-		}
-	}
-
 }

--- a/package.json
+++ b/package.json
@@ -132,6 +132,9 @@
     "typescript": "^3.2.2",
     "vsce": "^1.71.0"
   },
+  "extensionDependencies": [
+    "salesforce.salesforcedx-vscode-core"
+  ],
   "scripts": {
     "vscode:package": "vsce package",
     "vscode:prepublish": "npm run compile",


### PR DESCRIPTION
### What does this PR do?
Updates the telemetry code to respect sfdx CLI settings if a user disables it there

There will be a separate PR for unit tests.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/salesforcedx-vscode-slds/issues/26