### PR TITLE
Update Non Windows environment to use node v12 - matching Windows config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
   build-all:
     description: 'Build artifacts in a non-Windows environment'
     docker:
-      - image: circleci/node:10.2.0
+      - image: circleci/node:12.20.0
     environment:
       - SFDX_URL_LINUX: https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
       - SFDX_AUTOUPDATE_DISABLE: true


### PR DESCRIPTION
### What does this PR do?
CI for non-window build is failing.

### What issues does this PR fix or reference?
Upgrade non-window node container to 12.20.0 to match the major version used in windows orbs. 