### PR TITLE
Update to LSP 0.0.9.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [1.4.3]
+- Update LSP: https://github.com/forcedotcom/salesforcedx-slds-lsp/releases/tag/v0.0.9
+
 ## [1.4.2]
 Updates/enhancements:
 - [Upgrade vscode client and add webpack configuration.](https://github.com/forcedotcom/salesforcedx-vscode-slds/commit/29217452fa8643d865c9059fc185c24ce3ad6e75)

--- a/client/src/sldsLanguageClient.ts
+++ b/client/src/sldsLanguageClient.ts
@@ -165,7 +165,7 @@ function createServerPromise(context: ExtensionContext, outputChannel: OutputCha
 			}
 
 			args.push('-jar');
-			args.push(path.resolve(context.extensionPath, 'lsp-0.0.8-executable.jar'));
+			args.push(path.resolve(context.extensionPath, 'lsp-0.0.9-executable.jar'));
 			args.push(`--PORT=${port.toString()}`);
 
 			let process = child_process.spawn(javaExecutablePath, args, options);

--- a/client/test/suite/telemetry/index.test.ts
+++ b/client/test/suite/telemetry/index.test.ts
@@ -11,7 +11,7 @@ const proxyquire = require('proxyquire').noCallThru();
 const CLIPath = '../../../src/telemetry/cliConfiguration';
 import { ENV_SFDX_CLI_DISABLE_TELEMETRY, SFDX_CONFIG_DISABLE_TELEMETRY} from '../../../src/telemetry/utils';
 
-suite('Telementry', function () {
+suite('Telemetry', function () {
 	setup(() => {
 		delete process.env[ENV_SFDX_CLI_DISABLE_TELEMETRY];
 	});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "salesforce-vscode-slds",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "salesforce-vscode-slds",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "hasInstallScript": true,
       "devDependencies": {
         "@salesforce/dev-config": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "SLDS Validator",
   "publisher": "salesforce",
   "description": "Salesforce Lightning Design System",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "aiKey": "7344b284-73e5-420e-b680-73333da3e067",
   "icon": "images/slds-icon.png",
   "preview": true,


### PR DESCRIPTION
### What does this PR do?
This PR updates LSP version to 0.0.9. The new LSP includes a validator that checks for using non-mobile friendly components.

### What issues does this PR fix or reference?
For more information on the newly added validator please see this [PR](https://github.com/forcedotcom/salesforcedx-slds-lsp/pull/27) from LSP project.
