### PR TITLE
Bump version to 1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.4.4]
+Bug fixes:
+- [Address issue with Telemetry Enabled](https://github.com/forcedotcom/salesforcedx-vscode-slds/commit/0294a2a70f345e0448a89b4e93ffd8072ff9b421)
+
 ## [1.4.3]
 - Update LSP: https://github.com/forcedotcom/salesforcedx-slds-lsp/releases/tag/v0.0.9
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "salesforce-vscode-slds",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "salesforce-vscode-slds",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "hasInstallScript": true,
       "devDependencies": {
         "@salesforce/dev-config": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "SLDS Validator",
   "publisher": "salesforce",
   "description": "Salesforce Lightning Design System",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "aiKey": "7344b284-73e5-420e-b680-73333da3e067",
   "icon": "images/slds-icon.png",
   "preview": true,


### PR DESCRIPTION
### What does this PR do?
This PR bumps the package's version number to 1.4.4. This version includes a bug fix when telemetry was enabled.

### What issues does this PR fix or reference?
Package tagged with 1.4.4 shall include this bug [fix](https://github.com/forcedotcom/salesforcedx-vscode-slds/commit/0294a2a70f345e0448a89b4e93ffd8072ff9b421).