### PR TITLE
update to LSP 0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [1.4.6]
+- Update LSP: https://github.com/forcedotcom/salesforcedx-slds-lsp/releases/tag/v0.0.11
+
 ## [1.4.5]
 Bug fixes:
 - [Address SFDX package detection](https://github.com/forcedotcom/salesforcedx-vscode-slds/pull/85/commits/c951f3273b4ff16eb6846fae6f43e525c3d19bdb)

--- a/client/src/sldsLanguageClient.ts
+++ b/client/src/sldsLanguageClient.ts
@@ -165,7 +165,7 @@ function createServerPromise(context: ExtensionContext, outputChannel: OutputCha
 			}
 
 			args.push('-jar');
-			args.push(path.resolve(context.extensionPath, 'lsp-0.0.10-executable.jar'));
+			args.push(path.resolve(context.extensionPath, 'lsp-0.0.11-executable.jar'));
 			args.push(`--PORT=${port.toString()}`);
 
 			let process = child_process.spawn(javaExecutablePath, args, options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "salesforce-vscode-slds",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "salesforce-vscode-slds",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "hasInstallScript": true,
       "devDependencies": {
         "@salesforce/dev-config": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "SLDS Validator",
   "publisher": "salesforce",
   "description": "Salesforce Lightning Design System",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "aiKey": "7344b284-73e5-420e-b680-73333da3e067",
   "icon": "images/slds-icon.png",
   "preview": true,


### PR DESCRIPTION
### What does this PR do?
This PR updates LSP version to 0.0.11, which contains an update to the warning message that is displayed for non-mobile-friendly components.

### What issues does this PR fix or reference?
For more information on the newly added validator please see this [PR](https://github.com/forcedotcom/salesforcedx-slds-lsp/pull/31) from LSP project.