### PR TITLE
Publish VSIX artifact in GitHub release

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,3 +27,4 @@ Once latest changes are merged in:
 1. Create a GitHub release with the newly pushed tag here: https://github.com/forcedotcom/salesforcedx-vscode-slds/releases/new
 1. Release title should be `Release vMajor.Minor.Patch`
 1. Release description should be the latest changelog entry (from above)
+1. Upload the validator VSIX file as part of the release


### PR DESCRIPTION
### What does this PR do?
This PR adds an instruction to the releasing guide to upload the packaged validator VSIX file as part of the GitHub release. This gives users an alternative to the VSCode Marketplace as a place to find the extension release artifacts. Alternatives are important for users that use open source alternatives to VSCode such as [code-server](https://github.com/coder/code-server), since the license of the VSCode Marketplace seems to limit its use to VSCode only.

### What issues does this PR fix or reference?
N/A