### PR TITLE
@W-17361533@ v2.0.12 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [2.0.12]
+- Ruleset Separation
+  - Breaks out various rules into their own categories in both sarif reporter and in Vscode smells
+    - BEM
+    - DEPRECATED
+    - DENSITY
+- Readded SLDS2 Classes for 252.14 Patch
+  - In an effort to ensure users have a smooth transition from SLDS1 -> SLDS2 several classes from SLDS1 have been reintroduced to SLDS2 and will no longer show up as deprecated in the validator.
+
 ## [2.0.11]
 - Various Sarif Reporting Fixes
   - Fixes various issues with larger repositories

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "salesforce-vscode-slds",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "salesforce-vscode-slds",
-      "version": "2.0.11",
+      "version": "2.0.12",
       "hasInstallScript": true,
       "devDependencies": {
         "@salesforce/dev-config": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "SLDS Validator",
   "publisher": "salesforce",
   "description": "Salesforce Lightning Design System",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "aiKey": "7344b284-73e5-420e-b680-73333da3e067",
   "icon": "images/slds-icon.png",
   "preview": true,


### PR DESCRIPTION
## [2.0.12]
- Ruleset Separation
  - Breaks out various rules into their own categories in both sarif reporter and in Vscode smells
    - BEM
    - DEPRECATED
    - DENSITY
- Readded SLDS2 Classes for 252.14 Patch
  - In an effort to ensure users have a smooth transition from SLDS1 -> SLDS2 several classes from SLDS1 have been reintroduced to SLDS2 and will no longer show up as deprecated in the validator.